### PR TITLE
helpers: adopt padToggle for "Desktop Notifications" setting

### DIFF
--- a/desktop_notifications.js
+++ b/desktop_notifications.js
@@ -1,19 +1,35 @@
 'use strict';
 
-const eejs = require('ep_etherpad-lite/node/eejs/');
-const settings = require('ep_etherpad-lite/node/utils/Settings');
-let checkedState = '';
+const {padToggle} = require('ep_plugin_helpers/pad-toggle-server');
 
-exports.eejsBlock_mySettings = (hookName, args, cb) => {
-  if (!settings.ep_desktop_notifications_default) checkedState = 'checked';
-  args.content +=
-    eejs.require('ep_desktop_notifications/templates/desktop_notifications_entry.ejs',
-        {
-          checked: checkedState,
-        },
-    );
-  return cb();
+// Parallel User Settings + Pad Wide Settings checkboxes for "Desktop
+// Notifications". Helper owns markup, storage, broadcast, enforce, and i18n.
+const desktopToggle = padToggle({
+  pluginName: 'ep_desktop_notifications',
+  settingId: 'desktopNotifications',
+  l10nId: 'ep_desktop_notifications.desktopNotifications',
+  defaultLabel: 'Desktop Notifications',
+  defaultEnabled: true,
+});
+
+// The previous version honored a top-level `ep_desktop_notifications_default`
+// key with inverted semantics (truthy = default off). Translate to the
+// helper's nested `defaultEnabled` so existing installs keep their behavior.
+exports.loadSettings = async (hookName, args) => {
+  const root = args && args.settings;
+  if (root) {
+    const ps = (root.ep_desktop_notifications = root.ep_desktop_notifications || {});
+    if (typeof ps.defaultEnabled !== 'boolean' &&
+        typeof root.ep_desktop_notifications_default === 'boolean') {
+      ps.defaultEnabled = !root.ep_desktop_notifications_default;
+    }
+  }
+  return desktopToggle.loadSettings(hookName, args);
 };
+
+exports.clientVars = desktopToggle.clientVars;
+exports.eejsBlock_mySettings = desktopToggle.eejsBlock_mySettings;
+exports.eejsBlock_padSettings = desktopToggle.eejsBlock_padSettings;
 
 exports.eejsBlock_styles = (hookName, args, cb) => {
   const url = '../static/plugins/ep_desktop_notifications/static/css/desktop_notifications.css';

--- a/ep.json
+++ b/ep.json
@@ -2,12 +2,17 @@
   "parts": [
     {
       "name": "ep_desktop_notifications",
+      "hooks": {
+        "loadSettings": "ep_desktop_notifications/desktop_notifications",
+        "clientVars": "ep_desktop_notifications/desktop_notifications",
+        "eejsBlock_mySettings": "ep_desktop_notifications/desktop_notifications",
+        "eejsBlock_padSettings": "ep_desktop_notifications/desktop_notifications",
+        "eejsBlock_styles": "ep_desktop_notifications/desktop_notifications"
+      },
       "client_hooks": {
         "postAceInit": "ep_desktop_notifications/static/js/desktop_notifications:postAceInit",
-        "chatNewMessage": "ep_desktop_notifications/static/js/desktop_notifications:chatNewMessage"
-      },
-      "hooks": {
-        "eejsBlock_mySettings": "ep_desktop_notifications/desktop_notifications"
+        "chatNewMessage": "ep_desktop_notifications/static/js/desktop_notifications:chatNewMessage",
+        "handleClientMessage_CLIENT_MESSAGE": "ep_desktop_notifications/static/js/desktop_notifications:handleClientMessage_CLIENT_MESSAGE"
       }
     }
   ]

--- a/package.json
+++ b/package.json
@@ -34,5 +34,8 @@
   "scripts": {
     "lint": "eslint .",
     "lint:fix": "eslint --fix ."
+  },
+  "dependencies": {
+    "ep_plugin_helpers": "^0.5.2"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,10 @@ settings:
 importers:
 
   .:
+    dependencies:
+      ep_plugin_helpers:
+        specifier: ^0.5.2
+        version: 0.5.2
     devDependencies:
       eslint:
         specifier: ^8.57.1
@@ -399,6 +403,10 @@ packages:
   enhanced-resolve@5.20.1:
     resolution: {integrity: sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==}
     engines: {node: '>=10.13.0'}
+
+  ep_plugin_helpers@0.5.2:
+    resolution: {integrity: sha512-6M0gYqRTaF2SnTvV1OiqOZQ4B37ZHL0Zjoz3/eOIAXeCEBA4jId62uz9uboLs87Qcfae7eirDYWpdir5u5zkEQ==}
+    engines: {node: '>=18.0.0'}
 
   es-abstract@1.24.2:
     resolution: {integrity: sha512-2FpH9Q5i2RRwyEP1AylXe6nYLR5OhaJTZwmlcP0dL/+JCbgg7yyEo/sEK6HeGZRf3dFpWwThaRHVApXSkW3xeg==}
@@ -1672,6 +1680,8 @@ snapshots:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.3.2
+
+  ep_plugin_helpers@0.5.2: {}
 
   es-abstract@1.24.2:
     dependencies:

--- a/static/js/desktop_notifications.js
+++ b/static/js/desktop_notifications.js
@@ -1,6 +1,25 @@
 'use strict';
 /* global webkitNotifications */
 
+// Sub-path import keeps the client bundle clean — the top-level
+// `ep_plugin_helpers` index pulls in server-only modules.
+const {padToggle} = require('ep_plugin_helpers/pad-toggle');
+const padcookie = require('ep_etherpad-lite/static/js/pad_cookie').padcookie;
+
+// Same config as the server-side instance — must agree on pluginName,
+// settingId, l10nId, and defaultLabel so checkbox ids and clientVars line up.
+const desktopToggle = padToggle({
+  pluginName: 'ep_desktop_notifications',
+  settingId: 'desktopNotifications',
+  l10nId: 'ep_desktop_notifications.desktopNotifications',
+  defaultLabel: 'Desktop Notifications',
+  defaultEnabled: true,
+});
+
+// Re-export so the helper sees pad-wide broadcasts and refreshes our state
+// when another user toggles the pad-wide checkbox.
+exports.handleClientMessage_CLIENT_MESSAGE = desktopToggle.handleClientMessage_CLIENT_MESSAGE;
+
 const DesktopNotifications = {
   /* compatilibility layer */
   notificationSupported: () => !!window.Notification || !!window.webkitNotifications,
@@ -108,29 +127,24 @@ const postAceInit = (hook, context) => {
   DesktopNotifications.status = false;
   DesktopNotifications.helpShown = false;
 
-  /* init */
-  const $optionsDesktopNotifications = $('#options-desktopNotifications');
-  const urlDesktopNotifications = DesktopNotifications.getParam('DesktopNotifications');
-  if (urlDesktopNotifications === 'true') {
-    $optionsDesktopNotifications.attr('checked', 'checked');
-  } else if (urlDesktopNotifications === 'false') {
-    $optionsDesktopNotifications.attr('checked', false);
-  }
-  if ($optionsDesktopNotifications.is(':checked')) {
-    DesktopNotifications.handleNotificationPermission(
-        DesktopNotifications.notificationPermission()
-    );
-  } else {
-    DesktopNotifications.disable();
-  }
+  // The README documents `?DesktopNotifications=true|false` as a way to
+  // override the toggle. Now that the helper persists per-user state in
+  // padcookie, write the URL value into the cookie before init reads it
+  // — that way the override survives reload, matching the original intent.
+  const urlOverride = DesktopNotifications.getParam('DesktopNotifications');
+  if (urlOverride === 'true') padcookie.setPref('desktopNotifications', true);
+  else if (urlOverride === 'false') padcookie.setPref('desktopNotifications', false);
 
-  /* on click */
-  $optionsDesktopNotifications.click(() => {
-    if ($optionsDesktopNotifications.is(':checked')) {
-      DesktopNotifications.enable();
-    } else {
-      DesktopNotifications.disable();
-    }
+  desktopToggle.init({
+    onChange: (enabled) => {
+      if (enabled) {
+        DesktopNotifications.handleNotificationPermission(
+            DesktopNotifications.notificationPermission()
+        );
+      } else {
+        DesktopNotifications.disable();
+      }
+    },
   });
 };
 

--- a/templates/desktop_notifications_entry.ejs
+++ b/templates/desktop_notifications_entry.ejs
@@ -1,4 +1,0 @@
-<p>
-<input type="checkbox" data-l10n-id="ep_desktop_notifications.desktopNotifications" id="options-desktopNotifications" <%= checked %>></input>
-<label for="options-desktopNotifications" data-l10n-id="ep_desktop_notifications.desktopNotifications">Desktop Notifications</label>
-</p>


### PR DESCRIPTION
## Summary

- Replace the manual `eejsBlock_mySettings` template with `padToggle` from `ep_plugin_helpers`. Parallel User Settings / Pad Wide Settings checkboxes for free; helper owns markup, storage, broadcast, enforce, and i18n.
- Slim `static/js/desktop_notifications.js` to use `padToggle.init({onChange})` instead of hand-rolled DOM init + click binding.
- **Side benefits:**
  - Adds per-user persistence — the previous version had none (the checkbox lost its state on reload).
  - Drops the redundant `data-l10n-id` on the `<input>` in the template (l10n on a checkbox input is meaningless; only the `<label>` needs it).
  - Fixes a request-state-leak bug where module-scoped `checkedState` was mutated on first request and never reset on subsequent ones.
- The README-documented `?DesktopNotifications=true|false` URL override is preserved — and now actually sticks across reloads (the override is written into padcookie before init reads it), matching the documented intent.
- Backward compat: existing installs that set the legacy top-level `ep_desktop_notifications_default` key (truthy = default off) keep their behavior; `loadSettings` translates it into the helper's nested `defaultEnabled`.

## Test plan

- [x] `pnpm run lint`
- [x] Server-side smoke test (Node): module loads, exports the five hooks, `eejsBlock_mySettings` produces valid `<input>`/`<label>` markup with `data-l10n-id`, legacy `ep_desktop_notifications_default: true` translates to `defaultEnabled: false`.
- [ ] CI green (backend + frontend tests)
- [ ] In a pad: open User Settings, toggle "Desktop Notifications" — browser permission prompt fires on enable; reload preserves the chosen state.
- [ ] `?DesktopNotifications=false` in the URL forces it off and persists across the next reload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)